### PR TITLE
Automatic debugpy setup

### DIFF
--- a/.config/nvim/.gitignore
+++ b/.config/nvim/.gitignore
@@ -1,1 +1,2 @@
-./plugin
+plugin
+plugin/

--- a/.config/nvim/lua/core/plugin_config/debugger/debugging.lua
+++ b/.config/nvim/lua/core/plugin_config/debugger/debugging.lua
@@ -1,17 +1,15 @@
-require('dapui').setup()
+require("dapui").setup()
 
 local dapui = require("dapui")
-local dap = require('dap')
-local dap_ext_vscode = require('dap.ext.vscode')
-local dap_python = require('dap-python')
+local dap = require("dap")
+local dap_ext_vscode = require("dap.ext.vscode")
+local dap_python = require("dap-python")
 
--- local helper = require('lua.core.plugin_config.debugger.helper')
---
--- local debugpy_path = helper.get_debugpy("~/.virtualenvs")
--- print("debugpy_path:", debugpy_path)
+local helper = require("core.plugin_config.debugger.helper")
 
-dap_python.setup('~/.virtualenvs/debugpy/bin/python')
-require('nvim-dap-virtual-text').setup()
+-- Default debugpy setup
+dap_python.setup("~/.virtualenvs/debugpy/bin/python")
+require("nvim-dap-virtual-text").setup()
 
 -- Look and feel
 vim.fn.sign_define('DapBreakpoint', { text='🐞', texthl='DapBreakpoint', linehl='DapBreakpoint', numhl='DapBreakpoint' })
@@ -26,6 +24,9 @@ vim.api.nvim_set_keymap('n', '<leader>dt', ':lua require("dapui").toggle()<CR>',
 vim.api.nvim_set_keymap('n', '<leader>dr', ':lua require("dapui").open({reset = true})<CR>', {noremap=true})
 vim.keymap.set("n", "<F5>",
   function()
+    if vim.bo.filetype == "python" then
+      dap_python.setup(helper.get_debugpy(helper.constants.DEBUGPY_VENV_DIR))
+    end
     dap_ext_vscode.load_launchjs(nil, {})
     dap.continue()
   end

--- a/.config/nvim/lua/core/plugin_config/debugger/debugpy_picker.lua
+++ b/.config/nvim/lua/core/plugin_config/debugger/debugpy_picker.lua
@@ -5,41 +5,10 @@ local actions = require "telescope.actions"
 local action_state = require "telescope.actions.state"
 local dap_python = require('dap-python')
 
--- local helper = require('lua.core.plugin_config.debugger.helper')
+local helper = require("core.plugin_config.debugger.helper")
 
 
-local python_debuggers_path = "~/.virtualenvs/"
-
-
-local function get_python_venvs(directory)
-    local debuggers = {}
-
-    local directories = io.popen("find " ..directory.. " -maxdepth 1 -type d | sed 1d")
-    if directories == nil then
-      print("No debuggers found.")
-      return {}
-    end
-
-    local i = 1
-    for debugger in directories:lines() do
-      -- get python version 
-      local version = io.popen(debugger.. "/bin/python --version")
-      if version == nil then
-        print("Couldn't get versions.")
-        return {}
-      end
-      local python_version = version:read("*a"):gsub("\n", "")
-      version:close()
-
-      -- get relative paths
-      debuggers[#debuggers+1] = { "󰌠 ".. python_version, debugger .. "/bin/python" }
-
-      i = i + 1
-    end
-    directories:close()
-
-    return debuggers
-end
+local python_debuggers_path = helper.constants.DEBUGPY_VENV_DIR
 
 
 local function enter(prompt_bufnr)
@@ -47,7 +16,7 @@ local function enter(prompt_bufnr)
   local debugger = vim.inspect(selected.value[2])
 
   dap_python.setup(debugger)
-  vim.schedule(function() vim.api.nvim_out_write("Debugger set to: ".. selected.value[1] .."\n") end)
+  vim.schedule(function() vim.api.nvim_out_write("Debugger set to: " .. selected.value[1] .. "\n") end)
 
   actions.close(prompt_bufnr)
 end
@@ -67,7 +36,7 @@ local appearance = {
 local opts = {
   prompt_title = "Python debuggers",
   finder = finders.new_table {
-    results = get_python_venvs(python_debuggers_path),
+    results = helper.get_python_venvs(python_debuggers_path, "󰌠"),
     entry_maker = function(entry)
       return {
         value = entry,

--- a/.config/nvim/lua/core/plugin_config/debugger/helper.lua
+++ b/.config/nvim/lua/core/plugin_config/debugger/helper.lua
@@ -1,11 +1,20 @@
+--#region Constants
+local constants = {
+  DEBUGPY_VENV_DIR = "~/.virtualenvs/"
+}
+--#endregion
+
+
+--#region Functions
+
 ---Execute a custom command and get output as string
----@param command string
----@return string
+---@param command any
+---@return string|nil
 local function execute_command(command)
   local exec = io.popen(command)
   if exec == nil then
-    print("Couldn't execute command: " .. command)
-    return ""
+    print("Couldn't execute command: " .. command .. "\n")
+    return nil
   end
 
   local output_string = exec:read("*a"):gsub("\n", "")
@@ -17,7 +26,7 @@ end
 
 ---Get Python venvs and their versions from a provided directory
 ---@param directory string
----@param python_icon any
+---@param python_icon string|nil
 ---@return table
 local function get_python_venvs(directory, python_icon)
   if python_icon == nil then
@@ -30,23 +39,16 @@ local function get_python_venvs(directory, python_icon)
 
   local directories = io.popen("find " .. directory .. " -maxdepth 1 -type d | sed 1d")
   if directories == nil then
-    print("No debuggers found.")
+    print("No debuggers found.\n")
     return {}
   end
 
   local i = 1
   for debugger in directories:lines() do
     -- get python version 
-    -- local version = io.popen(debugger .. "/bin/python --version")
-    -- if version == nil then
-    --   print("Couldn't get versions.")
-    --   return {}
-    -- end
-    -- local python_version = version:read("*a"):gsub("\n", "")
-    -- version:close()
-    local python_version = execute_command(debugger .. "/bin/python -- version")
-    if python_version == "" then
-      print("Couldn't get versions.")
+    local python_version = execute_command(debugger .. "/bin/python --version")
+    if python_version == nil then
+      print("Couldn't get versions.\n")
       return {}
     end
 
@@ -68,56 +70,74 @@ end
 ---@param directory string
 ---@return string
 local function get_debugpy(directory)
-  local default = directory .. "/debugpy/bin/python"
+  local default = directory .. "debugpy/bin/python"
   local debuggers = get_python_venvs(directory, nil)
   local venv = os.getenv("VIRTUAL_ENV")
 
   if vim.bo.filetype ~= "python" then
-    vim.api.nvim_out_write("This isn't a Python file")
+    vim.api.nvim_out_write(
+      "Not a python file\n" ..
+      "Using default debugging environment: " .. default .. "\n"
+    )
     return default
   end
 
   if venv == nil or venv == "" then
-    vim.api.nvim_out_write("No venv in use. Using default debugging environment")
+    vim.api.nvim_out_write(
+      "No venv in use.\n" ..
+      "Using default debugging environment: " .. default .. "\n"
+    )
     return default
   end
 
   local venv_version = execute_command(venv .. "/bin/python --version")
+  if venv_version == nil then
+    vim.api.nvim_out_write(
+      "Couldn't find your venv Python version.\n" ..
+      "Using default debugging environment: " .. default .. "\n"
+    )
+    return default
+  end
+
   for _, debugger in ipairs(debuggers) do
     local version = debugger[1]
 
     -- if coresponding version exists, use that one
     if version == venv_version then
-      vim.api.nvim_out_write("Debugging environment set to: " .. debugger[2])
+      vim.api.nvim_out_write("Debugging environment set to: " .. debugger[2] .. "\n")
       return debugger[2]  -- debugger venv path to bin/python
     end
   end
 
   -- else, create a new debugger environment for it
   local debugpy_path = string.format(
-    "%s/debugpy%s",
+    "%sdebugpy%s",
     directory,
     string.match(venv_version, "%d+%.%d+%.%d+")
   )
 
-  vim.api.nvim_out_write("Creating a new debugging environment ...")
+  vim.api.nvim_out_write("Creating a new debugging environment ...\n")
   local exec = execute_command(
     string.format("python -m venv %s && ", debugpy_path) ..
     string.format("%s/bin/python -m pip install debugpy", debugpy_path)
   )
   if exec ~= "" then
-    vim.api.nvim_out_write("Debugging environment set to: " .. debugpy_path)
+    vim.api.nvim_out_write("Debugging environment set to: " .. debugpy_path .. "\n")
     return debugpy_path
   end
 
-  vim.api.nvim_out_write("Using default debugging environment")
+  vim.api.nvim_out_write("Using default debugging environment\n")
   return default
 end
+
+--#endregion
 
 
 return {
   execute_command = execute_command,
   get_python_venvs = get_python_venvs,
-  get_debugpy = get_debugpy
+  get_debugpy = get_debugpy,
+
+  constants = constants
 }
 

--- a/.config/nvim/lua/core/plugins.lua
+++ b/.config/nvim/lua/core/plugins.lua
@@ -1,6 +1,5 @@
 local ensure_packer = function()
-  local fn = vim.fn
-  local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
+  local fn = vim.fn local install_path = fn.stdpath('data')..'/site/pack/packer/start/packer.nvim'
   if fn.empty(fn.glob(install_path)) > 0 then
     fn.system({'git', 'clone', '--depth', '1', 'https://github.com/wbthomason/packer.nvim', install_path})
     vim.cmd [[packadd packer.nvim]]


### PR DESCRIPTION
This MR adds automatic DAP Python setup, depending to the user's Python venv.

### How it works?
First check if the file I'm trying to debug is a python file. If it is, then check if I'm using a venv and if I am, check which Python version is in use. If the debugpy venv of the same version exists, then choose that one, otherwise create the new one and use it. If none of that is true, then use a default setting.